### PR TITLE
Fix tooltips not appearing

### DIFF
--- a/scripts/render.js
+++ b/scripts/render.js
@@ -110,7 +110,7 @@ const tooltipScript = `
     visibleTooltip = tooltip;
   }
   document.addEventListener("mousedown", e => {
-    const tooltipParent = e.path.filter(element => element.classList?.contains("tooltipParent"))[0];
+    const tooltipParent = e.composedPath().filter(element => element.classList?.contains("tooltipParent"))[0];
     if (tooltipParent) {
       const tooltip = tooltipParent.querySelector(".tooltipText");
       if (tooltip) {


### PR DESCRIPTION
Modern browsers don't support `path`, so `composedPath()` must be used.